### PR TITLE
Fix `bundle install` by changing twitter-oauth to twitter_oauth.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
-source :rubygems
+source 'https://rubygems.org'
+
 gem "tweetstream"
 gem "highline"
-gem "twitter-oauth"
+gem "twitter_oauth"


### PR DESCRIPTION
This also gets rid of a deprecation warning from bundler by changing
the rubygems source to use a string, not the symbol.
