### PR TITLE
Update paths for Ruby 1.9 compatibility

### DIFF
--- a/lib/pd-connect.rb
+++ b/lib/pd-connect.rb
@@ -5,7 +5,7 @@
 #
 
 require 'socket'
-require 'lib/character'
+require './lib/character'
 require 'yaml'
 
 class PureData

--- a/scripts/manual-input.rb
+++ b/scripts/manual-input.rb
@@ -17,7 +17,7 @@
 # The above command will use this file to read and sonify this file including this comment about reading and sonifying this file.
 #
 
-require 'lib/pd-connect'
+require './lib/pd-connect'
 
 # If the first argument is a valid file, place a flag to skip prompts
 begin


### PR DESCRIPTION
Fixes this error I saw when running under Ruby 1.9:

```
cannot load such file -- lib/pd-connect (LoadError)
```

In 1.9, the current directory isn't in the load path, so I just made the requires more explicit.
